### PR TITLE
Allow event overrides (move/remove/moveall/removeall)

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -234,6 +234,22 @@ $("#demo2-add-clear").click(function() {
         <td><code>filterOnValues</code></td>
         <td><code><strong>false</strong></code>: set this to <code>true</code> to filter the options according to their values and not their HTML contents.</td>
       </tr>
+      <tr>
+        <td><code>eventMoveOverride</code></td>
+        <td><code><strong>false</strong></code>: set this to <code>true</code> to allow your own implementation of the move event.</td>
+      </tr>
+      <tr>
+        <td><code>eventMoveAllOverride</code></td>
+        <td><code><strong>false</strong></code>: set this to <code>true</code> to allow your own implementation of the moveall event.</td>
+      </tr>
+      <tr>
+        <td><code>eventRemoveOverride</code></td>
+        <td><code><strong>false</strong></code>: set this to <code>true</code> to allow your own implementation of the remove event.</td>
+      </tr>
+      <tr>
+        <td><code>eventRemoveAllOverride</code></td>
+        <td><code><strong>false</strong></code>: set this to <code>true</code> to allow your own implementation of the removeall event.</td>
+      </tr>
     </tbody>
   </table>
 
@@ -351,6 +367,22 @@ $(selector).bootstrapDualListbox(methodName, parameter);</pre>
       <tr>
         <td><code>setFilterOnValues(value, refresh)</code></td>
         <td>change the <code>filterOnValues</code> parameter.</td>
+      </tr>
+      <tr>
+        <td><code>setEventMoveOverride(value, refresh)</code></td>
+        <td>change the <code>eventMoveOverride</code> parameter.</td>
+      </tr>
+      <tr>
+        <td><code>setEventMoveAllOverride(value, refresh)</code></td>
+        <td>change the <code>eventMoveAllOverride</code> parameter.</td>
+      </tr>
+      <tr>
+        <td><code>setEventRemoveOverride(value, refresh)</code></td>
+        <td>change the <code>eventRemoveOverride</code> parameter.</td>
+      </tr>
+      <tr>
+        <td><code>setEventRemoveAllOverride(value, refresh)</code></td>
+        <td>change the <code>eventRemoveAllOverride</code> parameter.</td>
       </tr>
     </tbody>
   </table>

--- a/src/jquery.bootstrap-duallistbox.js
+++ b/src/jquery.bootstrap-duallistbox.js
@@ -22,7 +22,11 @@
       infoTextFiltered: '<span class="label label-warning">Filtered</span> {0} from {1}', // when not all of the options are visible due to the filter
       infoTextEmpty: 'Empty list',                                                        // when there are no options present in the list
       filterOnValues: false,                                                              // filter by selector's values, boolean
-      sortByInputOrder: false
+      sortByInputOrder: false,
+      eventMoveOverride: false,                                                           // boolean, allows user to unbind default event behaviour and run their own instead
+      eventMoveAllOverride: false,                                                        // boolean, allows user to unbind default event behaviour and run their own instead
+      eventRemoveOverride: false,                                                         // boolean, allows user to unbind default event behaviour and run their own instead
+      eventRemoveAllOverride: false                                                       // boolean, allows user to unbind default event behaviour and run their own instead
     },
     // Selections are invisible on android if the containing select is styled with CSS
     // http://code.google.com/p/android/issues/detail?id=16922
@@ -313,21 +317,29 @@
       dualListbox.setSelectedFilter('', true);
     });
 
-    dualListbox.elements.moveButton.on('click', function() {
-      move(dualListbox);
-    });
+    if (dualListbox.settings.eventMoveOverride === false) {
+      dualListbox.elements.moveButton.on('click', function() {
+        move(dualListbox);
+      });
+    }
 
-    dualListbox.elements.moveAllButton.on('click', function() {
-      moveAll(dualListbox);
-    });
+    if (dualListbox.settings.eventMoveAllOverride === false) {
+      dualListbox.elements.moveAllButton.on('click', function() {
+        moveAll(dualListbox);
+      });
+    }
 
-    dualListbox.elements.removeButton.on('click', function() {
-      remove(dualListbox);
-    });
+    if (dualListbox.settings.eventRemoveOverride === false) {
+      dualListbox.elements.removeButton.on('click', function() {
+        remove(dualListbox);
+      });
+    }
 
-    dualListbox.elements.removeAllButton.on('click', function() {
-      removeAll(dualListbox);
-    });
+    if (dualListbox.settings.eventRemoveAllOverride === false) {
+      dualListbox.elements.removeAllButton.on('click', function() {
+        removeAll(dualListbox);
+      });
+    }
 
     dualListbox.elements.filterInput1.on('change keyup', function() {
       filter(dualListbox, 1);
@@ -441,6 +453,10 @@
       this.setInfoTextEmpty(this.settings.infoTextEmpty);
       this.setFilterOnValues(this.settings.filterOnValues);
       this.setSortByInputOrder(this.settings.sortByInputOrder);
+      this.setEventMoveOverride(this.settings.eventMoveOverride);
+      this.setEventMoveAllOverride(this.settings.eventMoveAllOverride);
+      this.setEventRemoveOverride(this.settings.eventRemoveOverride);
+      this.setEventRemoveAllOverride(this.settings.eventRemoveAllOverride);
 
       // Hide the original select
       this.element.hide();
@@ -677,6 +693,34 @@
     },
     setSortByInputOrder: function(value, refresh){
         this.settings.sortByInputOrder = value;
+        if (refresh) {
+          refreshSelects(this);
+        }
+        return this.element;
+    },
+    setEventMoveOverride: function(value, refresh) {
+        this.settings.eventMoveOverride = value;
+        if (refresh) {
+          refreshSelects(this);
+        }
+        return this.element;
+    },
+    setEventMoveAllOverride: function(value, refresh) {
+        this.settings.eventMoveAllOverride = value;
+        if (refresh) {
+          refreshSelects(this);
+        }
+        return this.element;
+    },
+    setEventRemoveOverride: function(value, refresh) {
+        this.settings.eventRemoveOverride = value;
+        if (refresh) {
+          refreshSelects(this);
+        }
+        return this.element;
+    },
+    setEventRemoveAllOverride: function(value, refresh) {
+        this.settings.eventRemoveAllOverride = value;
         if (refresh) {
           refreshSelects(this);
         }


### PR DESCRIPTION
Allows avoiding the execution of default events, skipping the `saveSelections` call so everybody can implement their own method for handling whatever the buttons trigger. 

The options:

``` javascript
      eventMoveOverride: false,
      eventMoveAllOverride: false,
      eventRemoveOverride: false,
      eventRemoveAllOverride: false

```

are set to `false` by default, so the plugin preserves the default behavior unless specified otherwise.
